### PR TITLE
Beta 8

### DIFF
--- a/FULL_TRANSLATION_CHECKLIST.md
+++ b/FULL_TRANSLATION_CHECKLIST.md
@@ -1,0 +1,104 @@
+# Directorist + WPML: Full Translation Checklist
+
+This document lists **what is translatable**, **what you must do in WPML**, and any **gaps** so you can make Directorist fully translated.
+
+---
+
+## 1. What YOU must do in WPML (your side)
+
+### 1.1 WPML → Settings → Custom Fields / Term Meta
+
+| Item | Setting to use | Why |
+|------|----------------|-----|
+| **`search_form_fields`** (Term Meta) | **Don't translate** | Integration translates labels/placeholders at runtime via String Translation. Translating the raw meta would break the form config. |
+| **`submission_form_fields`** (Term Meta) | **Don't translate** | Same: integration translates add-listing fields/sections at runtime. |
+| Other Directorist term meta (e.g. `submit_button_label`, `single_listing_page`, etc.) | **Don't translate** or **Copy** | Use **Translate** only for simple display-only text you are not translating elsewhere. |
+
+### 1.2 WPML → String Translation
+
+You (or a translator) must **add translations** for:
+
+- **Directorist plugin domain (`directorist`)**  
+  Directorist uses `__()`, `_e()`, etc. with text domain `directorist`. WPML scans the plugin and lists these. Translate them in **WPML → String Translation** (filter by domain `directorist`).
+
+- **Integration domain (`directorist-wpml-integration`)**  
+  Our plugin registers strings here. After you visit pages that use:
+  - Search form
+  - Add listing form
+  - **Select2 dropdowns** (Category/Location: “No results found”, “Searching…”, “Loading more…”, etc. → all **`select2_*`** strings; see **JS_STRINGS_TRANSLATION.md**)
+  - Directory type names
+  - Blocks/widgets (with custom titles/text)
+  - Options (when they are used on frontend)  
+  …these strings appear in String Translation. Filter by domain **directorist-wpml-integration** and translate them.
+
+- **Admin texts (`atbdp_option`)**  
+  Listed in `wpml-config.xml` under `<admin-texts>`. They appear in **WPML → String Translation** (or Translation Editor). Translate so labels, buttons, email templates, etc. show in each language.
+
+### 1.3 Translate content (pages, taxonomy terms, listings)
+
+- **Pages**: All listings, Add listing, Dashboard, etc. — create translations for each language (or use WPML’s “Translate” for the page and assign the correct language).
+- **Taxonomies**: Categories, Locations, Tags — translate terms in **WPML → Taxonomy Translation** (or when editing the term, set language and add translation).
+- **Directory types** (`atbdp_listing_types`): Translate directory type names (e.g. “General”, “Rental”) so they show in the correct language. Integration helps display the translated name.
+- **Listings (ATBDP post type)**: Translate each listing (title, content, custom fields marked “translate” in wpml-config) via WPML’s post translation.
+
+### 1.4 Language switcher and URLs
+
+- Integration adjusts **Directorist-specific URLs** (all listings, category, location, tag, author, pagination, checkout, etc.) so the language switcher points to the correct translated URL. No extra setting needed if WPML and the integration are active.
+
+---
+
+## 2. What the integration plugin makes translatable (automatically)
+
+| Area | How it works | Fully translatable? |
+|------|----------------|----------------------|
+| **Search form fields** | `Search_Form_Field_Translation`: hooks `directorist_template`, translates `$args['data']` (label, placeholder, description, options, pricing min/max, radius min/max) per directory. Strings: `search_form_dir_{id}_field_{slug}_{property}`. | Yes, once strings are translated in String Translation. |
+| **Add listing form** | `Add_Listing_Form_Translation`: hooks `directorist_form_field_data`, `directorist_section_template`, `atbdp_add_listing_page_template`. Translates field labels/placeholders/options and section labels (sidebar + headers). | Yes, once strings are translated. |
+| **Directorist options** | `Option_Translation`: hooks `directorist_option`. Translates display strings from `get_directorist_option()` (skips query/ID keys). `Settings_Registration` registers option strings when saved. | Yes, for options that are display strings (and in admin-texts where configured). |
+| **Directory type names** | `Directory_Translation`: hooks `directorist_directories_for_template`, `get_terms`, `term_name`. Translates directory type labels. | Yes. |
+| **Gutenberg blocks** | `Block_Widget_Translation`: hooks `render_block_data` + `render_block`. Translates block attributes (e.g. search bar title, header title, button text). | Yes, for attributes listed in plugin + wpml-config. |
+| **Elementor widgets** | `Block_Widget_Translation`: hooks `elementor/widget/render_content`. Translates widget settings (titles, labels, etc.) per widget. | Yes, for widgets/fields in plugin + wpml-config. |
+| **Listings query** | `Query_Filtering`: ensures only current-language listings; translates `tax_query` term IDs. `Search_Form_Filter`: filters categories/locations/tags in search by language. | Yes (language filtering). |
+| **Listing count** | `Listing_Count_Filter`: keeps counts per language. | Yes. |
+| **Permalinks / URLs** | `Filter_Permalinks`: all listings, category/location/tag singles, author, pagination, checkout, edit listing, etc. | Yes. |
+| **Emails** | `Email_Translation`: switches WPML language to the listing’s language before sending so Directorist’s email templates use the right language. | Yes, if email template strings are translated (Directorist + admin texts). |
+| **Listing duplication/translation** | `Listings_Actions`: keeps directory type when copying/translating listings via WPML. | Yes. |
+| **REST API** | `REST_API`: sets content language for Directorist REST requests. | Yes for language context. |
+
+---
+
+## 3. Directorist plugin (without integration)
+
+| Source | Domain | Handled by |
+|--------|--------|------------|
+| All PHP strings in Directorist using `__()`, `_e()`, `esc_html__()`, etc. | `directorist` | WordPress/WPML — appear in **String Translation** under domain `directorist`. You must translate them. |
+| Custom post type `at_biz_dir` | — | wpml-config: `translate="1"`. WPML treats listings as translatable. |
+| Taxonomies (category, location, tags, listing types) | — | wpml-config: `translate="1"`. Use Taxonomy Translation. |
+| Custom fields (listing meta) | — | wpml-config: copy/translate/ignore per field. |
+| Admin texts (atbdp_option keys) | atbdp_option | wpml-config + Option_Translation. Translate in String Translation. |
+| Gutenberg blocks / Elementor widgets | — | wpml-config declares keys; Block_Widget_Translation translates at runtime. |
+
+---
+
+## 4. Gaps / “Not fully translatable” without extra work
+
+| Item | Why | What you can do |
+|------|-----|------------------|
+| **Search form: directory_id** | String names use `search_form_dir_{directory_id}_...`. If the directory type has a **different term ID per language** (WPML taxonomy translation), the key differs and translations registered for one ID won’t apply for the other. | Use the same directory type ID for string naming across languages (e.g. map to default-language term ID in the integration), or add translations for each language’s directory ID. |
+| **Hardcoded or third-party strings** | Any text not coming from Directorist or the integration (e.g. theme, another plugin) | Translate in String Translation under the relevant domain or use WPML’s theme/plugin scan. |
+| **JS-rendered text** | Text only in JavaScript (e.g. “Load more”) | Directorist usually passes these from PHP; if any are only in JS, they need to be localized (wp_localize_script) and then translated. |
+| **New block/widget attributes** | New Directorist blocks or new attributes added by Directorist | Add them to `Block_Widget_Translation` and to `wpml-config.xml` in the integration. |
+
+---
+
+## 5. Quick checklist: “Is everything translatable?”
+
+- [ ] **WPML**: Term Meta for `search_form_fields` and `submission_form_fields` = **Don't translate**.
+- [ ] **WPML → String Translation**: Translated all strings for domain **directorist** (Directorist core).
+- [ ] **WPML → String Translation**: Translated all strings for domain **directorist-wpml-integration** (search form, add listing, directory names, options, blocks/widgets).
+- [ ] **WPML → String Translation**: Translated **admin texts** (atbdp_option) used on frontend and in emails.
+- [ ] **WPML**: Translated **pages** (All Listings, Add Listing, Dashboard, etc.) per language.
+- [ ] **WPML**: Translated **taxonomies** (categories, locations, tags) and **directory types**.
+- [ ] **WPML**: Translated **listings** (post type at_biz_dir) and their translatable custom fields.
+- [ ] **Content**: Each language has the same **structure** (e.g. search form block/widget present on the translated “All Listings” page) so the integration can translate the strings.
+
+If all boxes are done, Directorist is fully set up for translation; the integration covers runtime translation of search form, add listing form, options, directory names, blocks/widgets, queries, permalinks, and emails.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,19 @@
 # Directorist WPML Integration
-A WPML integration extension for Directorist
 
+Official WPML integration extension for [Directorist](https://directorist.com) that lets you build fully multilingual directory sites.
 
-<!-- Security scan triggered at 2025-09-02 21:06:27 -->
+## Key features
+
+- Syncs Directorist listings, directory types, categories, locations and tags across WPML languages.
+- Makes Directorist settings, search forms, widgets/blocks and email templates translatable via WPML String Translation.
+- Automatically syncs category `_directory_type` meta and directory `_default` flags across translations (as of 2.2.1).
+- Tested with WordPress 6.9, PHP 7.4+, and the latest WPML core and addons.
+
+## Changelog (short)
+
+- **2.2.0 (2026‑02‑05)**  
+  - Added automatic syncing of Directorist category directory assignments across WPML languages.  
+  - Added WPML config for copying the default directory type flag across translations.  
+  - Improved overall compatibility with WordPress 6.8 and current WPML releases.
+
+For full details, see `readme.txt` or the [plugin page](https://github.com/sovware/directorist-wpml-integration).

--- a/app/Controller/Hook/Category_Directory_Sync.php
+++ b/app/Controller/Hook/Category_Directory_Sync.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Directorist_WPML_Integration\Controller\Hook;
+
+
+
+class Category_Directory_Sync {
+
+    /**
+     * Constructor.
+     *
+     * Registers term‑creation and term‑edit hooks for the listing category
+     * taxonomy so we can mirror directory assignments from the original term.
+     */
+    public function __construct() {
+        // When a translated category is created or edited, sync its directory meta.
+        add_action( 'created_' . ATBDP_CATEGORY, [ $this, 'sync_category_directory' ], 20, 2 );
+        add_action( 'edited_' . ATBDP_CATEGORY, [ $this, 'sync_category_directory' ], 20, 2 );
+    }
+
+    /**
+     * Check if WPML core is active enough for our integration.
+     *
+     * @return bool
+     */
+    private function is_wpml_active() {
+        return defined( 'ICL_SITEPRESS_VERSION' )
+            && function_exists( 'apply_filters' )
+            && has_filter( 'wpml_current_language' )
+            && has_filter( 'wpml_default_language' )
+            && has_filter( 'wpml_object_id' );
+    }
+
+
+    public function sync_category_directory( $term_id, $tt_id ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter
+        // Ensure Directorist helper function and WPML are available.
+        if ( ! function_exists( 'directorist_update_category_directory' ) ) {
+            return;
+        }
+
+        if ( ! $this->is_wpml_active() ) {
+            return;
+        }
+
+        // WPML languages.
+        $current_lang = apply_filters( 'wpml_current_language', null );
+        $default_lang = apply_filters( 'wpml_default_language', null );
+
+        // Nothing to sync if language context is missing or we are in default language.
+        if ( empty( $current_lang ) || $current_lang === $default_lang ) {
+            return;
+        }
+
+        $term_id       = (int) $term_id;
+        $original_term = apply_filters( 'wpml_object_id', $term_id, ATBDP_CATEGORY, true, $default_lang );
+        $original_term = (int) $original_term;
+
+        // If WPML reports this term as its own original, there is nothing to sync.
+        if ( ! $original_term || $original_term === $term_id ) {
+            return;
+        }
+
+        // Get directory IDs from the original language category.
+        $orig_dir_ids = (array) get_term_meta( $original_term, '_directory_type', true );
+        if ( empty( $orig_dir_ids ) ) {
+            return;
+        }
+
+        // Translate each directory ID into the current language.
+        $translated_dir_ids = [];
+
+        foreach ( $orig_dir_ids as $orig_dir_id ) {
+            $orig_dir_id = (int) $orig_dir_id;
+            if ( ! $orig_dir_id ) {
+                continue;
+            }
+
+            $translated_dir_id = apply_filters(
+                'wpml_object_id',
+                $orig_dir_id,
+                ATBDP_DIRECTORY_TYPE,
+                true,
+                $current_lang
+            );
+
+            if ( $translated_dir_id ) {
+                $translated_dir_ids[] = (int) $translated_dir_id;
+            }
+        }
+
+        $translated_dir_ids = array_unique( array_filter( $translated_dir_ids ) );
+
+        if ( empty( $translated_dir_ids ) ) {
+            return;
+        }
+
+        // Update the translated category with the translated directory IDs.
+        // We do NOT append here; we want the translated term’s `_directory_type`
+        // to mirror the original term in its own language.
+        directorist_update_category_directory( $term_id, $translated_dir_ids, false );
+    }
+}
+

--- a/app/Controller/Hook/Init.php
+++ b/app/Controller/Hook/Init.php
@@ -40,9 +40,11 @@ class Init {
             Search_Form_Filter::class,
             Search_Form_Field_Translation::class,
             Add_Listing_Form_Translation::class,
+            Selectfield_Translation::class,
 
             Directory_Translation::class,
             Block_Widget_Translation::class,
+            Sorting_Options_Translation::class,
 
         ];
     }

--- a/app/Controller/Hook/Init.php
+++ b/app/Controller/Hook/Init.php
@@ -31,6 +31,7 @@ class Init {
             Filter_Permalinks::class,
             Directory_Builder_Actions::class,
             Listings_Actions::class,
+            Category_Directory_Sync::class,
             Email_Translation::class,
 
             Settings_Registration::class,

--- a/app/Controller/Hook/Selectfield_Translation.php
+++ b/app/Controller/Hook/Selectfield_Translation.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * Select2 JS strings translation
+ *
+ * Directorist uses the Select2 JS library for Category/Location dropdowns.
+ * Select2's UI strings (No results found, Searching…, etc.) are hardcoded in
+ * the vendor JS, so they never appear in WPML String Translation. This class
+ * registers all known Select2 strings with WPML and injects translated text
+ * into Select2's default language so dropdowns show in the current language.
+ *
+ * For other JS-originated strings: Directorist passes most UI text via
+ * wp_localize_script (the "directorist" object) from PHP, so those are already
+ * translatable via WPML (domain "directorist"). Only vendor/third-party
+ * strings that never go through PHP need to be handled here or in similar hooks.
+ *
+ * @package Directorist_WPML_Integration
+ */
+
+namespace Directorist_WPML_Integration\Controller\Hook;
+
+class Selectfield_Translation {
+
+	const WPML_DOMAIN = 'directorist-wpml-integration';
+	const STRING_PREFIX = 'select2_';
+
+	/**
+	 * Select2 language keys and their default (English) values.
+	 * Keys match Select2's i18n API (noResults, searching, etc.).
+	 *
+	 * @var array<string, string>
+	 */
+	private static $strings = [
+		'no_results'        => 'No results found',
+		'searching'         => 'Searching…',
+		'loading_more'      => 'Loading more results…',
+		'input_too_short'   => 'Please enter {count} or more characters',
+		'input_too_long'    => 'Please delete {count} character',
+		'input_too_long_pl' => 'Please delete {count} characters',
+		'maximum_selected'  => 'You can only select {count} item',
+		'maximum_selected_pl' => 'You can only select {count} items',
+		'error_loading'     => 'The results could not be loaded.',
+		'remove_all_items'  => 'Remove all items',
+	];
+
+	/**
+	 * Constructor
+	 */
+	public function __construct() {
+		add_action( 'init', [ $this, 'register_strings' ], 20 );
+		add_action( 'wp_enqueue_scripts', [ $this, 'inject_select2_language' ], 20 );
+	}
+
+	/**
+	 * Register all Select2 strings with WPML so they appear in String Translation
+	 */
+	public function register_strings() {
+		if ( ! $this->is_wpml_active() ) {
+			return;
+		}
+		foreach ( self::$strings as $key => $default ) {
+			$name = self::STRING_PREFIX . $key;
+			do_action( 'wpml_register_single_string', self::WPML_DOMAIN, $name, $default );
+		}
+	}
+
+	/**
+	 * Translate a single string via WPML
+	 *
+	 * @param string $key    Key in self::$strings
+	 * @param string $default Default text
+	 * @return string
+	 */
+	private function translate( $key, $default ) {
+		$name = self::STRING_PREFIX . $key;
+		$out  = apply_filters( 'wpml_translate_single_string', $default, self::WPML_DOMAIN, $name );
+		return is_string( $out ) ? $out : $default;
+	}
+
+	/**
+	 * Output translated strings into Select2 defaults so Category/Location dropdowns are translated
+	 */
+	public function inject_select2_language() {
+		if ( ! $this->is_wpml_active() ) {
+			return;
+		}
+
+		$no_results   = $this->translate( 'no_results', self::$strings['no_results'] );
+		$searching    = $this->translate( 'searching', self::$strings['searching'] );
+		$loading_more = $this->translate( 'loading_more', self::$strings['loading_more'] );
+		$input_short  = $this->translate( 'input_too_short', self::$strings['input_too_short'] );
+		$input_long   = $this->translate( 'input_too_long', self::$strings['input_too_long'] );
+		$input_long_pl = $this->translate( 'input_too_long_pl', self::$strings['input_too_long_pl'] );
+		$max_sel      = $this->translate( 'maximum_selected', self::$strings['maximum_selected'] );
+		$max_sel_pl   = $this->translate( 'maximum_selected_pl', self::$strings['maximum_selected_pl'] );
+		$error_load   = $this->translate( 'error_loading', self::$strings['error_loading'] );
+		$remove_all   = $this->translate( 'remove_all_items', self::$strings['remove_all_items'] );
+
+		$js = sprintf(
+			"jQuery(function(){if(!jQuery.fn.select2)return;var d=jQuery.fn.select2.defaults.defaults;d.language=d.language||{};var L=d.language;L.noResults=function(){return %s;};L.searching=function(){return %s;};L.loadingMore=function(){return %s;};L.inputTooShort=function(e){var n=(e.minimum-(e.input||'').length);return (%s).replace(/{count}/g,n);};L.inputTooLong=function(e){var n=(e.input||'').length-e.maximum;return (n===1?%s:%s).replace(/{count}/g,n);};L.maximumSelected=function(e){return (e.maximum===1?%s:%s).replace(/{count}/g,e.maximum);};L.errorLoading=function(){return %s;};L.removeAllItems=function(){return %s;};});",
+			wp_json_encode( $no_results ),
+			wp_json_encode( $searching ),
+			wp_json_encode( $loading_more ),
+			wp_json_encode( $input_short ),
+			wp_json_encode( $input_long ),
+			wp_json_encode( $input_long_pl ),
+			wp_json_encode( $max_sel ),
+			wp_json_encode( $max_sel_pl ),
+			wp_json_encode( $error_load ),
+			wp_json_encode( $remove_all )
+		);
+
+		wp_add_inline_script( 'directorist-select2-script', $js, 'after' );
+	}
+
+	/**
+	 * Check if WPML is active
+	 *
+	 * @return bool
+	 */
+	private function is_wpml_active() {
+		return defined( 'ICL_SITEPRESS_VERSION' )
+			&& function_exists( 'do_action' )
+			&& function_exists( 'apply_filters' );
+	}
+}

--- a/app/Controller/Hook/Sorting_Options_Translation.php
+++ b/app/Controller/Hook/Sorting_Options_Translation.php
@@ -1,0 +1,283 @@
+<?php
+/**
+ * Sorting Options Translation
+ * 
+ * Translates the hardcoded sorting/orderby options and view options in Directorist listings.
+ * These strings use __() with 'directorist' text domain but may not be picked up
+ * by WPML's automatic scanning, so we register and translate them manually.
+ * 
+ * @package Directorist_WPML_Integration
+ * @since 2.1.7
+ */
+
+namespace Directorist_WPML_Integration\Controller\Hook;
+
+class Sorting_Options_Translation {
+
+    /**
+     * WPML String Translation Domain
+     * 
+     * @var string
+     */
+    const WPML_DOMAIN = 'directorist-wpml-integration';
+
+    /**
+     * Constructor
+     * 
+     * @return void
+     */
+    public function __construct() {
+        // Filter the orderby options to translate labels
+        add_filter( 'atbdp_get_listings_orderby_options', [ $this, 'translate_orderby_options' ], 20, 1 );
+        
+        // Filter the view as link list via template filter
+        // Since there's no filter for atbdp_get_listings_view_options, we filter the template output
+        add_filter( 'directorist_template', [ $this, 'translate_view_options_in_template' ], 10, 2 );
+        
+        // Register strings on init (only once, admin side preferred)
+        add_action( 'init', [ $this, 'register_sorting_strings' ], 20 );
+    }
+
+    /**
+     * Check if WPML is active
+     * 
+     * @return bool
+     */
+    private function is_wpml_active() {
+        return (
+            defined( 'ICL_SITEPRESS_VERSION' ) &&
+            function_exists( 'do_action' ) &&
+            function_exists( 'apply_filters' )
+        );
+    }
+
+    /**
+     * Get all sorting option strings that need translation
+     * 
+     * These match the strings in atbdp_get_listings_orderby_options()
+     * located in directorist/includes/helper-functions.php
+     * 
+     * @return array Key => English string pairs
+     */
+    private function get_sorting_strings() {
+        return [
+            'title-asc'  => 'A to Z (title)',
+            'title-desc' => 'Z to A (title)',
+            'date-desc'  => 'Latest listings',
+            'date-asc'   => 'Oldest listings',
+            'views-desc' => 'Popular listings',
+            'price-asc'  => 'Price (low to high)',
+            'price-desc' => 'Price (high to low)',
+            'rand'       => 'Random listings',
+        ];
+    }
+
+    /**
+     * Get all view option strings that need translation
+     * 
+     * These match the strings in atbdp_get_listings_view_options()
+     * located in directorist/includes/helper-functions.php
+     * 
+     * @return array Key => English string pairs
+     */
+    private function get_view_strings() {
+        return [
+            'grid' => 'Grid',
+            'list' => 'List',
+            'map'  => 'Map',
+        ];
+    }
+
+    /**
+     * Register sorting and view strings with WPML String Translation
+     * 
+     * This ensures the strings appear in WPML > String Translation
+     * under our domain for easy translation.
+     * 
+     * @return void
+     */
+    public function register_sorting_strings() {
+        if ( ! $this->is_wpml_active() ) {
+            return;
+        }
+
+        // Only register on admin or if explicitly needed
+        // This reduces frontend overhead
+        if ( ! is_admin() && ! $this->is_first_frontend_load() ) {
+            return;
+        }
+
+        // Register sorting options
+        $sorting_strings = $this->get_sorting_strings();
+        foreach ( $sorting_strings as $key => $label ) {
+            $string_name = 'sorting_option_' . $key;
+            $this->register_wpml_string( $string_name, $label );
+        }
+
+        // Register view options
+        $view_strings = $this->get_view_strings();
+        foreach ( $view_strings as $key => $label ) {
+            $string_name = 'view_option_' . $key;
+            $this->register_wpml_string( $string_name, $label );
+        }
+    }
+
+    /**
+     * Check if this might be first frontend load (for initial registration)
+     * 
+     * @return bool
+     */
+    private function is_first_frontend_load() {
+        // Check if any sorting strings are already registered
+        // If not, we should register them
+        if ( ! function_exists( 'icl_get_string_id' ) ) {
+            return true;
+        }
+
+        $test_string_id = icl_get_string_id( 'A to Z (title)', self::WPML_DOMAIN, 'sorting_option_title-asc' );
+        
+        return empty( $test_string_id );
+    }
+
+    /**
+     * Translate orderby options
+     * 
+     * Hook: atbdp_get_listings_orderby_options
+     * Priority: 20 (after Directorist filters out disabled options)
+     * 
+     * @param array $orderby_options Array of orderby options [key => label]
+     * @return array Translated orderby options
+     */
+    public function translate_orderby_options( $orderby_options ) {
+        if ( ! $this->is_wpml_active() ) {
+            return $orderby_options;
+        }
+
+        if ( empty( $orderby_options ) || ! is_array( $orderby_options ) ) {
+            return $orderby_options;
+        }
+
+        $sorting_strings = $this->get_sorting_strings();
+
+        foreach ( $orderby_options as $key => $label ) {
+            // Check if this is a known sorting option
+            if ( ! isset( $sorting_strings[ $key ] ) ) {
+                continue;
+            }
+
+            $string_name = 'sorting_option_' . $key;
+            
+            // Get the original English string (in case Directorist already translated it)
+            $original_label = $sorting_strings[ $key ];
+            
+            // Register the string (WPML ignores duplicates)
+            $this->register_wpml_string( $string_name, $original_label );
+            
+            // Translate the string
+            $translated = $this->translate_wpml_string( $original_label, $string_name );
+            
+            // Only update if we got a translation
+            if ( ! empty( $translated ) && $translated !== $original_label ) {
+                $orderby_options[ $key ] = $translated;
+            }
+        }
+
+        return $orderby_options;
+    }
+
+    /**
+     * Translate view options in template args
+     * 
+     * Hook: directorist_template
+     * Priority: 10
+     * 
+     * Since there's no filter for atbdp_get_listings_view_options(),
+     * we intercept the template loading and modify the listings object's views property.
+     * 
+     * @param string $template Template name
+     * @param array $args Template arguments
+     * @return string Template name (unchanged)
+     */
+    public function translate_view_options_in_template( $template, $args ) {
+        // Only process viewas dropdown template
+        if ( strpos( $template, 'archive/viewas-dropdown' ) === false ) {
+            return $template;
+        }
+
+        if ( ! $this->is_wpml_active() ) {
+            return $template;
+        }
+
+        // Check if listings object exists with views property
+        if ( empty( $args['listings'] ) || ! is_object( $args['listings'] ) ) {
+            return $template;
+        }
+
+        $listings = $args['listings'];
+        
+        if ( ! isset( $listings->views ) || ! is_array( $listings->views ) ) {
+            return $template;
+        }
+
+        $view_strings = $this->get_view_strings();
+
+        foreach ( $listings->views as $key => $label ) {
+            if ( ! isset( $view_strings[ $key ] ) ) {
+                continue;
+            }
+
+            $string_name = 'view_option_' . $key;
+            $original_label = $view_strings[ $key ];
+            
+            // Register the string (WPML ignores duplicates)
+            $this->register_wpml_string( $string_name, $original_label );
+            
+            // Translate the string
+            $translated = $this->translate_wpml_string( $original_label, $string_name );
+            
+            // Only update if we got a translation
+            if ( ! empty( $translated ) && $translated !== $original_label ) {
+                $listings->views[ $key ] = $translated;
+            }
+        }
+
+        return $template;
+    }
+
+    /**
+     * Register string with WPML
+     * 
+     * @param string $string_name String name/context
+     * @param string $string_value String value
+     * @return void
+     */
+    private function register_wpml_string( $string_name, $string_value ) {
+        if ( ! function_exists( 'do_action' ) ) {
+            return;
+        }
+        
+        if ( is_string( $string_value ) && ! empty( $string_value ) ) {
+            do_action( 'wpml_register_single_string', self::WPML_DOMAIN, $string_name, $string_value );
+        }
+    }
+
+    /**
+     * Translate WPML string
+     * 
+     * @param string $string_value Original string value
+     * @param string $string_name String name/context
+     * @return string Translated string
+     */
+    private function translate_wpml_string( $string_value, $string_name ) {
+        if ( ! function_exists( 'apply_filters' ) ) {
+            return $string_value;
+        }
+        
+        return apply_filters(
+            'wpml_translate_single_string',
+            $string_value,
+            self::WPML_DOMAIN,
+            $string_name
+        );
+    }
+}

--- a/directorist-wpml-integration.php
+++ b/directorist-wpml-integration.php
@@ -4,10 +4,10 @@
  * Plugin URI: https://github.com/sovware/directorist-wpml-integration
  * Description: WPML integration plugin for Directorist.
  * Requires Plugins: directorist
- * Version: 2.2.0
+ * Version: 2.2.1
  * Requires at least: 6.0
  * Requires PHP: 7.4
- * Tested up to: 6.8
+ * Tested up to: 6.9
  * Author: wpWax
  * Author URI: https://directorist.com/about-us
  * Text Domain: directorist-wpml-integration

--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,9 @@
 Contributors: wpwax
 Tags: directory, directorist, directorist wpml, wpml
 Requires at least: 5.7
-Tested up to: 6.8
+Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 2.2.0
+Stable tag: 2.2.1
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -59,14 +59,16 @@ If you want to contribute to the project, you’re most welcome to make it happe
 3. Use the `Add New` button in the Block Editor toolbar when needed.
 
 == Changelogs == 
-2.2.0 - Jan 15, 2026
+2.2.1 - Feb 05, 2026
 
-* Fixed: string translation 
-* Fixed: New translatable data is available for translation and displays correctly on the front-end
-* Fixed: Data saved in posts is still translatable and displays correctly in the front-end.
-* Fixed: Data saved in taxonomies is still translatable and displays correctly on the front-end.
-* Fixed: Front-end strings are still translatable with WPML String Translation and display correctly.
-* Fixed: Email sending process: content is translated and sent in the user’s preferred language.
+* Added: Built‑in synchronization of Directorist category `_directory_type` meta across WPML languages, based on WPML’s recommended workaround (no extra code snippet needed).
+* Added: WPML config to copy the `_default` directory type flag across translations, ensuring a proper default directory type per language.
+* Improved: Overall WPML compatibility for directory types, categories, search form fields, and settings strings on WordPress 6.8 and the latest WPML versions.
+* Fixed: New translatable data is available for translation and displays correctly on the front‑end.
+* Fixed: Data saved in posts remains translatable and displays correctly on the front‑end.
+* Fixed: Data saved in taxonomies remains translatable and displays correctly on the front‑end.
+* Fixed: Front‑end strings are translatable with WPML String Translation and display correctly.
+* Fixed: Email sending process so content is translated and sent in the user’s preferred language.
 
 2.1.4 - Jun 09, 2025
 

--- a/wpml-config.xml
+++ b/wpml-config.xml
@@ -12,6 +12,19 @@
         <taxonomy translate="1">atbdp_listing_types</taxonomy>
     </taxonomies>
 
+    <!--
+        Ensure each directory type term keeps the same "default" flag across all
+        languages so there is always a default directory type per language.
+        This mirrors WPML’s suggested configuration:
+
+        <custom-term-fields>
+          <custom-term-field action="copy">_default</custom-term-field>
+        </custom-term-fields>
+    -->
+    <custom-term-fields>
+        <custom-term-field action="copy">_default</custom-term-field>
+    </custom-term-fields>
+
     <admin-texts>
         <key name="atbdp_option">
             <!-- All Listings -->


### PR DESCRIPTION
### Description

This change implements **WPML-aware synchronization** for Directorist categories to ensure that the `_directory_type` term meta is properly copied from the original language and mapped to the corresponding translated directory types.

With this update:

* The `_directory_type` term meta is copied from the original category to its translations
* The copied `_directory_type` is correctly mapped to the translated directory type
* WPML configuration is added to copy the `_default` directory type flag across all languages
* Each language is guaranteed to have a valid default directory type
* `readme.txt` and `README.md` have been updated to document the new behavior
* Compatibility with WordPress 6.8 and current WPML versions has been confirmed

This is an internal integration/meta behavior change and does not introduce any UI changes.

---

### Screenshots

Not applicable – this change affects internal meta synchronization and WPML integration only (no UI changes).

---

### Types of changes

* Bug fix (non-breaking change which fixes an issue)
* New feature (non-breaking change which adds functionality)

---

### How has this been tested?

* Created directory types and categories in the default language
* Translated categories using WPML and verified that `_directory_type` term meta is correctly synced on translated categories
* Created listings, assigned categories, translated the listings, and confirmed that categories appear correctly in the translated listing edit screen
* Checked the PHP debug log to ensure there are no errors related to the new hooks or WPML configuration changes

---

### Checklist:

* [x] My code is tested
* [ ] I've included any necessary tests <!-- if applicable -->
* [x] I've included developer documentation <!-- changelog + README updates -->
* [ ] I've added proper labels to this pull request <!-- if applicable -->
